### PR TITLE
Disable checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
         -->
          <checkstyle.config.location>sun_checks.xml</checkstyle.config.location>
+         <checkstyle.skip>true</checkstyle.skip>
          <checkstyle.suppressions.location>config/checkstyle-suppressions.xml</checkstyle.suppressions.location>
     </properties>
 


### PR DESCRIPTION
Also, if you set the `jenkins-world-2017` branch as the default under settings on GitHub, this should be the branch that gets checked out initially after a fresh clone (making it easier for students).